### PR TITLE
Fix KeyError on API HTTP error.

### DIFF
--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -264,8 +264,8 @@ class WordpressJsonWrapper(object):
                 str(http_response.status_code),
                 str(http_response.reason),
                 ": ",
-                '[%s] %s' % (http_response.json()[0].get('code'),
-                             http_response.json()[0].get('message'))
+                '[%s] %s' % (http_response.json().get('code'),
+                             http_response.json().get('message'))
             ]))
         else:
             return http_response.json()


### PR DESCRIPTION
No need for the list access, as `http_response.json()` returns a dict.