### PR TITLE
Fix example v2 endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Usage
 
 .. code-block:: python
 
-    >>> wp = WordpressJsonWrapper('http://example.com/wp-json', 'wp_user', 'wp_password')
+    >>> wp = WordpressJsonWrapper('http://example.com/wp-json/wp/v2', 'wp_user', 'wp_password')
     >>> posts = wp.get_posts()
     >>> posts[0].keys()
     dict_keys(['format', 'featured_media', 'author', ...])


### PR DESCRIPTION
Minor update to the example in the README to use the proper v2 namespace `wp/v2`. See http://v2.wp-api.org/changes-beta-1.html under `External API`. There might be some other breaking changes, haven't checked.