### PR TITLE
Allow a request to contain non-JSON content.

### DIFF
--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -243,18 +243,18 @@ class WordpressJsonWrapper(object):
         if kw.get('headers'):
             headers = kw.get('headers')
 
-        return (method.upper(), endpoint, url_params, post_data, headers)
+        if 'application/json' not in headers.get('Content-Type', 'application/json'):
+            post_json = None
+        else:
+            post_json = post_data
+            post_data = None
+
+        return (method.upper(), endpoint, url_params, post_data, post_json, headers)
 
     def _request(self, method_name, **kw):
-        method, endpoint, params, data, headers = self._prepare_req(
+        method, endpoint, params, data, json, headers = self._prepare_req(
             method_name, **kw
         )
-
-        if 'application/json' not in headers.get('Content-Type', 'application/json'):
-            json = None
-        else:
-            json = data
-            data = None
 
         http_response = requests.request(
             method,

--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -250,7 +250,7 @@ class WordpressJsonWrapper(object):
             method_name, **kw
         )
 
-        if 'application/json' not in headers.get('Content-Type', ''):
+        if 'application/json' not in headers.get('Content-Type', 'application/json'):
             json = None
         else:
             json = data

--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -250,12 +250,19 @@ class WordpressJsonWrapper(object):
             method_name, **kw
         )
 
+        if 'application/json' not in headers.get('Content-Type', ''):
+            json = None
+        else:
+            json = data
+            data = None
+
         http_response = requests.request(
             method,
             self.site + endpoint,
             auth=self.auth,
             params=params,
-            json=data,
+            data=data,
+            json=json,
             headers=headers
         )
 


### PR DESCRIPTION
E.g. to upload an image:
```
   wp.create_media(
       headers={'Content-Disposition': 'attachment; filename=image.jpg',
                        'Content-Type': 'image/jpeg',
                       },
       data=image_data,
       )
```