### PR TITLE
fix filters with list values

### DIFF
--- a/wordpress_json/__init__.py
+++ b/wordpress_json/__init__.py
@@ -232,8 +232,12 @@ class WordpressJsonWrapper(object):
         # filters
         url_params = dict()
         if kw.get('filter'):
-            for query_param, value in six.iteritems(kw.get('filter')):
-                url_params.update({'filter[%s]' % query_param: value})
+            for query_param, values in six.iteritems(kw.get('filter')):
+                if isinstance(values, list):
+                    for i, value in enumerate(values):
+                        url_params.update({'filter[%s][%s]' % (query_param, i): value})
+                else:
+                    url_params.update({'filter[%s]' % query_param: value})
 
         # url params
         if kw.get('params'):


### PR DESCRIPTION
Given you have WordpressJsonWrapper instance

`wp = WordpressJsonWrapper()
`

if your plugin receives a list value on a filter

`wp.get_posts(filter={'filter_list': ['apple', 'tree']})
`

then your resquest must be something like

`curl "GET /wp-json/wp/v2/posts?filter%5Bfilter_list%5D=apple%5B0%5D&filter%5Bfilter_list%5D%5B1%5D=tree"
`

what means that your query string must be

`filter[filter_list]=apple[0]&filter[filter_list][1]=tree
`